### PR TITLE
remove imports from root module

### DIFF
--- a/database_setup_tools/setup.py
+++ b/database_setup_tools/setup.py
@@ -3,7 +3,7 @@ import threading
 import sqlalchemy_utils
 from sqlalchemy import MetaData
 
-from database_setup_tools import SessionManager
+from database_setup_tools.session_manager import SessionManager
 
 
 class DatabaseSetup:

--- a/tests/integration/test_database_setup.py
+++ b/tests/integration/test_database_setup.py
@@ -1,7 +1,7 @@
 import pytest
 from starlette.testclient import TestClient
 
-from database_setup_tools import DatabaseSetup
+from database_setup_tools.setup import DatabaseSetup
 from tests.integration.example.app import app, model_metadata, DATABASE_URI
 
 database_setup = DatabaseSetup(model_metadata=model_metadata, database_uri=DATABASE_URI)

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -1,6 +1,6 @@
 import pytest as pytest
 
-from database_setup_tools import SessionManager
+from database_setup_tools.session_manager import SessionManager
 
 
 class TestSessionManager:

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -2,7 +2,8 @@ import pytest
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.scoping import ScopedSession
 
-from database_setup_tools import DatabaseSetup, SessionManager
+from database_setup_tools.session_manager import SessionManager
+from database_setup_tools.setup import DatabaseSetup
 from tests.unit.sample_model import model_metadata
 
 


### PR DESCRIPTION
We already imported stuff from the root module, which is not a good practice for the code inside the package. 

Additionally, the publish action broke the `__init__.py`, so the root module doesn't export anything anymore - so everything was broken. We have to fix this behaviour anyway, but I wanted to make the package usable again as soon as possible