### PR TITLE
update & simplify documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 [![CodeQL](https://github.com/code-specialist/database-setup-tools/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/code-specialist/database-setup-tools/actions/workflows/github-code-scanning/codeql)
 [![Test](https://github.com/code-specialist/database-setup-tools/actions/workflows/test.yaml/badge.svg)](https://github.com/code-specialist/database-setup-tools/actions/workflows/test.yaml)
-![Py3.9](https://img.shields.io/badge/-Python%203.9-brightgreen)
-![Py3.10](https://img.shields.io/badge/-Python%203.10-brightgreen)
-![Py3.11](https://img.shields.io/badge/-Python%203.11-brightgreen)
 
 Simplified database lifecycle and session management based on [SQLModel](https://sqlmodel.tiangolo.com/) / [SQLAlchemy](https://www.sqlalchemy.org/).
 


### PR DESCRIPTION
I updated the documentation and simplified it as much as possible. I removed the full examples we had, I think for someone having the first look they might be too much.

I would create a hosted documentation website using GitHub pages that contains:
- Getting Started
- Features
- Examples (at least FastAPI + middleware, Pytest)
- API Reference

So the GitHub Readme is just an overview with the most important information and more detailed stuff can be found in the hosted docs

resolves #19 